### PR TITLE
D8-2772: expose per-queue node_count in the resource content API

### DIFF
--- a/src/Controller/ResourceDocumentationController.php
+++ b/src/Controller/ResourceDocumentationController.php
@@ -170,6 +170,7 @@ class ResourceDocumentationController extends ControllerBase {
       'queue_specs' => $this->getParagraphData($node, 'field_rp_queue_specs', [
         'field_rp_queue_name' => 'name',
         'field_rp_queue_purpose' => 'purpose',
+        'field_rp_node_count' => 'node_count',
         'field_rp_cpu_count' => 'cpu_count',
         'field_rp_cpus' => 'cpu_type',
         'field_rp_gpu_count' => 'gpu_count',
@@ -425,7 +426,7 @@ class ResourceDocumentationController extends ControllerBase {
   /**
    * Build a human-readable one-line summary of a queue spec.
    *
-   * E.g. "4 NVIDIA A100 (80 GB vRAM), 64-core AMD EPYC 7763, 256 GB RAM".
+   * E.g. "4 NVIDIA A100 (80 GB vRAM), 2 nodes, 64-core AMD EPYC 7763, 256 GB RAM".
    */
   private function buildQueueSummary(array $queue): ?string {
     $parts = [];
@@ -439,6 +440,10 @@ class ResourceDocumentationController extends ControllerBase {
         $gpu .= ' (' . $queue['gpu_vram'] . ' GB vRAM)';
       }
       $parts[] = $gpu;
+    }
+
+    if (isset($queue['node_count']) && $queue['node_count'] !== NULL && $queue['node_count'] !== '') {
+      $parts[] = (int) $queue['node_count'] . ' nodes';
     }
 
     if (!empty($queue['cpu_count']) && !empty($queue['cpu_type'])) {


### PR DESCRIPTION
Adds the per-queue node count to the resource documentation content API.

- Adds `field_rp_node_count` => `node_count` to the queue_specs field mapping in ResourceDocumentationController.
- Includes the node count in the derived buildQueueSummary() prose (e.g. "..., 100 nodes, ...").

Resources with queue specs will get a new content hash on next sync, which is the expected result of adding a field to the payload. No existing hash-assertion tests break.

Refs D8-2772